### PR TITLE
Don't perform the filter if language attribute is empty

### DIFF
--- a/src/Filters/KeywordFilter.php
+++ b/src/Filters/KeywordFilter.php
@@ -30,7 +30,7 @@
 		public static function filter(&$article)
 		{
 			// Can't perform this filter unless language is known
-			if(!isset($article->language))
+			if(!isset($article->language) || empty($article->language))
 			{
 				return;
 			}


### PR DESCRIPTION
Don't perform the filter if language attribute is empty

Related to issue #9 